### PR TITLE
Create frames dir

### DIFF
--- a/capture.py
+++ b/capture.py
@@ -2,9 +2,14 @@ import cv2
 import time
 from PIL import Image
 import numpy as np
+import os
 
 # Folder
 folder = "frames"
+
+# Create the frames folder if it doesn't exist
+frames_dir = os.path.join(os.getcwd(), folder)
+os.makedirs(frames_dir, exist_ok=True)
 
 # Initialize the webcam
 cap = cv2.VideoCapture(0)

--- a/capture.py
+++ b/capture.py
@@ -2,14 +2,9 @@ import cv2
 import time
 from PIL import Image
 import numpy as np
-import os
 
 # Folder
 folder = "frames"
-
-# Create the frames folder if it doesn't exist
-frames_dir = os.path.join(os.getcwd(), folder)
-os.makedirs(frames_dir, exist_ok=True)
 
 # Initialize the webcam
 cap = cv2.VideoCapture(0)


### PR DESCRIPTION
The `capture.py` script requires that the `frames` directory exists to write an image.

This PR updates the script to create that folder if it doesn't exist.