### PR TITLE
Parametrize voice ID via another environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,19 @@ export OPENAI_API_KEY=<token>
 export ELEVENLABS_API_KEY=<eleven-token>
 ```
 
-Make a new voice in Eleven and get the voice id of that voice using their [get voices](https://elevenlabs.io/docs/api-reference/voices) API.
+Make a new voice in Eleven and get the voice id of that voice using their [get voices](https://elevenlabs.io/docs/api-reference/voices) API, or by clicking the flask icon next to the voice in the VoiceLab tab.
+
+```
+export ELEVENLABS_VOICE_ID=<voice-id>
+```
 
 ## Run it!
 
+In on terminal, run the webcam capture:
 ```bash
 python capture.py
 ```
-In one terminal. In the other, run the narrator:
+In another terminal, run the narrator:
 
 ```bash
 python narrator.py

--- a/narrator.py
+++ b/narrator.py
@@ -5,10 +5,11 @@ import json
 import time
 import simpleaudio as sa
 import errno
-from elevenlabs import generate, play, voices
+from elevenlabs import generate, play, set_api_key, voices
 
 client = OpenAI()
 
+set_api_key(os.environ.get("ELEVENLABS_API_KEY"))
 
 def encode_image(image_path):
     while True:

--- a/narrator.py
+++ b/narrator.py
@@ -24,7 +24,7 @@ def encode_image(image_path):
 
 
 def play_audio(text):
-    audio = generate(text=text, voice="ENfvYmv6CRqDodDZTieQ", model="eleven_turbo_v2")
+    audio = generate(text, voice=os.environ.get("ELEVENLABS_VOICE_ID"))
 
     unique_id = base64.urlsafe_b64encode(os.urandom(30)).decode("utf-8").rstrip("=")
     dir_path = os.path.join("narration", unique_id)


### PR DESCRIPTION
# Objective

Make the capture.py script easier to use by parametrizing the voice ID via an environment variable, just like the Open AI and Eleven Labs API keys.

# Details

* Added the additional environment variable, along with an explanation of how to retrieve the Voice ID in the ElevenLabs API.
* Edited `capture.py` to use the environment variable.