### PR TITLE
[Setup] script and readme updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
+### Setup Script
+
+Alternatively, one can use the `setup.sh` script to facilitate getting the shell envs ready to rock by updating the API key values in `setup.sh` and run. 
+
+_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
+
+
 ## Run it!
 
 In on terminal, run the webcam capture:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# create a virtual environment
+python3 -m pip install virtualenv
+python3 -m virtualenv venv
+
+# source the virtual environment
+source venv/bin/activate
+
+# install the dependencies
+pip install -r requirements.txt
+
+# set the environment variables
+export ELEVENLABS_VOICE_ID=
+export OPENAI_API_KEY=
+export ELEVENLABS_API_KEY=


### PR DESCRIPTION
### Summary
- Added a `setup.sh` script to facilitate getting the two shell envs setup to run `capture.py` and `narrator.py`.
- Updated README with `setup.sh` usage info