### PR TITLE
[Streaming] capability added with setup script, readme updates, and narrator prompt update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /narration
 /frames/*
 !/frames/.gitkeep
+.env

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# David Attenborough narrates your life. 
+# David Attenborough narrates your life.
 
 https://twitter.com/charliebholtz/status/1724815159590293764
 
 ## Want to make your own AI app?
+
 Check out [Replicate](https://replicate.com). We make it easy to run machine learning models with an API.
 
 ## Setup
@@ -20,33 +21,41 @@ Then, install the dependencies:
 
 Make a [Replicate](https://replicate.com), [OpenAI](https://beta.openai.com/), and [ElevenLabs](https://elevenlabs.io) account and set your tokens:
 
-```
+```bash
 export OPENAI_API_KEY=<token>
 export ELEVENLABS_API_KEY=<eleven-token>
 ```
 
 Make a new voice in Eleven and get the voice id of that voice using their [get voices](https://elevenlabs.io/docs/api-reference/voices) API, or by clicking the flask icon next to the voice in the VoiceLab tab.
 
-```
+```bash
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
-### Setup Script
+### Streaming
 
-Alternatively, one can use the `setup.sh` script to facilitate getting the shell envs ready to rock by updating the API key values in `setup.sh` and run. 
+If you would like the speech to start quicker via a streaming manner set the environment variable to enable. The concession is that the audio snippet is not saved in the `/narration` directory.
+
+```bash
+export ELEVENLABS_STREAMING=true
+```
+
+### Script
+
+Alternative to running the commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock by updating the environment variable values in `setup.sh` and executing the script.
 
 _Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
-
 
 ## Run it!
 
 In on terminal, run the webcam capture:
+
 ```bash
 python capture.py
 ```
+
 In another terminal, run the narrator:
 
 ```bash
 python narrator.py
 ```
-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
+### Setup Script
+
+Alternatively, one can use the `setup.sh` script to facilitate getting the shell envs ready to rock by updating the API key values in `setup.sh` and run. 
+
+_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
+
+
 ## Run it!
 
 In on terminal, run the webcam capture:

--- a/narrator.py
+++ b/narrator.py
@@ -43,7 +43,7 @@ def generate_new_line(base64_image):
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Describe this image as if you David Attenborough"},
+                {"type": "text", "text": "Describe this image as if you are David Attenborough"},
                 {
                     "type": "image_url",
                     "image_url": f"data:image/jpeg;base64,{base64_image}",

--- a/narrator.py
+++ b/narrator.py
@@ -43,7 +43,7 @@ def generate_new_line(base64_image):
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Describe this image"},
+                {"type": "text", "text": "Describe this image as if you David Attenborough"},
                 {
                     "type": "image_url",
                     "image_url": f"data:image/jpeg;base64,{base64_image}",

--- a/setup.sh
+++ b/setup.sh
@@ -14,3 +14,5 @@ pip install -r requirements.txt
 export ELEVENLABS_VOICE_ID=
 export OPENAI_API_KEY=
 export ELEVENLABS_API_KEY=
+
+export ELEVENLABS_STREAMING=false

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# create a virtual environment
+python3 -m pip install virtualenv
+python3 -m virtualenv venv
+
+# source the virtual environment
+source venv/bin/activate
+
+# install the dependencies
+pip install -r requirements.txt
+
+# set the environment variables
+export ELEVENLABS_VOICE_ID=
+export OPENAI_API_KEY=
+export ELEVENLABS_API_KEY=


### PR DESCRIPTION
### Summary
- Added a `setup.sh` script to facilitate getting the two shell envs setup to run `capture.py` and `narrator.py`.Also, updated README with `setup.sh` usage info. From https://github.com/cbh123/narrator/pull/32
- Updated to the narrator GPT prompt to explicitly have it describe the image as David Attenborough for increased complex descriptors (and humor). From https://github.com/cbh123/narrator/pull/33
- Adds the ability to stream the Eleven Labs text to voice which creates a more immediate experience.
- Format linting