### PR TITLE
[PhotoBooth] mode with image persistence along side audio file. Also, streaming capabilities, setup script, readme updates, and narrator prompt update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Required variables:
+export OPENAI_API_KEY=
+export ELEVENLABS_API_KEY=
+export ELEVENLABS_VOICE_ID=
+
+# Optional variables:
+export ELEVENLABS_STREAMING=
+export PHOTOBOOTH_MODE=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /narration
 /frames/*
 !/frames/.gitkeep
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /narration
 /frames/*
 !/frames/.gitkeep
-.env
+.trunk

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# David Attenborough narrates your life. 
+# David Attenborough narrates your life.
 
 https://twitter.com/charliebholtz/status/1724815159590293764
 
 ## Want to make your own AI app?
+
 Check out [Replicate](https://replicate.com). We make it easy to run machine learning models with an API.
 
 ## Setup
@@ -20,33 +21,41 @@ Then, install the dependencies:
 
 Make a [Replicate](https://replicate.com), [OpenAI](https://beta.openai.com/), and [ElevenLabs](https://elevenlabs.io) account and set your tokens:
 
-```
+```bash
 export OPENAI_API_KEY=<token>
 export ELEVENLABS_API_KEY=<eleven-token>
 ```
 
 Make a new voice in Eleven and get the voice id of that voice using their [get voices](https://elevenlabs.io/docs/api-reference/voices) API, or by clicking the flask icon next to the voice in the VoiceLab tab.
 
-```
+```bash
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
-### Setup Script
+### Streaming
 
-Alternatively, one can use the `setup.sh` script to facilitate getting the shell envs ready to rock by updating the API key values in `setup.sh` and run. 
+If you would like the speech to start quicker via a streaming manner set the environment variable to enable. The concession is that the audio snippet is not saved in the `/narration` directory.
+
+```bash
+export ELEVENLABS_STREAMING=true
+```
+
+### Script
+
+Alternative to running the commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock by updating the environment variable values in `setup.sh` and executing the script.
 
 _Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
-
 
 ## Run it!
 
 In on terminal, run the webcam capture:
+
 ```bash
 python capture.py
 ```
+
 In another terminal, run the narrator:
 
 ```bash
 python narrator.py
 ```
-

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
+### Setup Script
+
+Alternatively, one can use the `setup.sh` script to facilitate getting the shell envs ready to rock by updating the API key values in `setup.sh` and run. 
+
+_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
+
+
 ## Run it!
 
 In on terminal, run the webcam capture:

--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
-### Streaming
-
-If you would like the speech to start quicker via a streaming manner set the environment variable to enable. The concession is that the audio snippet is not saved in the `/narration` directory.
-
-```bash
-export ELEVENLABS_STREAMING=true
-```
-
 ### Script
 
 Alternative to running the commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock by updating the environment variable values in `setup.sh` and executing the script.
@@ -58,4 +50,22 @@ In another terminal, run the narrator:
 
 ```bash
 python narrator.py
+```
+
+## Options
+
+### Streaming
+
+If you would like the speech to start quicker via a streaming manner set the environment variable to enable. The concession is that the audio snippet is not saved in the `/narration` directory.
+
+```bash
+export ELEVENLABS_STREAMING=true
+```
+
+### PhotoBooth
+
+The default behavior of this app will continually analyze images. If you would like to use in a mode more similar to a photo booth, set the environment variable. In this mode, the image will only be analyzed when the spacebar key is pressed.
+
+```bash
+export PHOTOBOOTH_MODE=true
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# David Attenborough narrates your life.
+# David Attenborough narrates your life
 
 https://twitter.com/charliebholtz/status/1724815159590293764
 
@@ -32,12 +32,6 @@ Make a new voice in Eleven and get the voice id of that voice using their [get v
 export ELEVENLABS_VOICE_ID=<voice-id>
 ```
 
-### Script
-
-Alternative to running the commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock by updating the environment variable values in `setup.sh` and executing the script.
-
-_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
-
 ## Run it!
 
 In on terminal, run the webcam capture:
@@ -53,6 +47,18 @@ python narrator.py
 ```
 
 ## Options
+
+### Setup
+
+#### Script
+
+Alternative to running the [Setup](#setup) commands above individually, one can use the `setup.sh` script to facilitate getting the two required shell envs ready to rock.
+
+_Note: may have to manually run `source source venv/bin/activate` afterwards depending on shell env._
+
+#### Dotenv
+
+One can set the environment variables via the `.env` file, which is read every time the process starts. It is recommended to copy the `.env.example` file and rename to `.env`.
 
 ### Streaming
 

--- a/capture.py
+++ b/capture.py
@@ -1,8 +1,9 @@
-import cv2
-import time
-from PIL import Image
-import numpy as np
 import os
+import time
+
+import cv2
+import numpy as np
+from PIL import Image
 
 # Folder
 folder = "frames"
@@ -30,7 +31,7 @@ while True:
         # Resize the image
         max_size = 250
         ratio = max_size / max(pil_img.size)
-        new_size = tuple([int(x*ratio) for x in pil_img.size])
+        new_size = tuple([int(x * ratio) for x in pil_img.size])
         resized_img = pil_img.resize(new_size, Image.LANCZOS)
 
         # Convert the PIL image back to an OpenCV image

--- a/narrator.py
+++ b/narrator.py
@@ -3,11 +3,15 @@ import errno
 import os
 import time
 
+from dotenv import load_dotenv
 from elevenlabs import generate, play, set_api_key, stream
 from openai import OpenAI
 from pynput import (  # Using pynput to listen for a keypress instead of native keyboard module which was requiring admin privileges
     keyboard,
 )
+
+# import environment variables from .env file
+load_dotenv()
 
 client = OpenAI()
 

--- a/narrator.py
+++ b/narrator.py
@@ -51,7 +51,7 @@ def play_audio(text):
         stream(audio)
         return
 
-    # Save the audio to a file and play it
+    # Save the audio to a file
     unique_id = base64.urlsafe_b64encode(os.urandom(30)).decode("utf-8").rstrip("=")
     dir_path = os.path.join("narration", unique_id)
     os.makedirs(dir_path, exist_ok=True)
@@ -60,6 +60,12 @@ def play_audio(text):
     with open(file_path, "wb") as f:
         f.write(audio)
 
+    # Copy the image analyzed to the same directory as the audio file
+    image_path = os.path.join(os.getcwd(), "./frames/frame.jpg")
+    new_image_path = os.path.join(dir_path, "image.jpg")
+    os.system(f"cp {image_path} {new_image_path}")
+
+    # Play the audio
     play(audio)
 
 

--- a/narrator.py
+++ b/narrator.py
@@ -1,6 +1,7 @@
 import base64
 import errno
 import os
+import shutil
 import time
 
 from dotenv import load_dotenv
@@ -63,9 +64,8 @@ def play_audio(text):
     # Copy the image analyzed to the same directory as the audio file
     image_path = os.path.join(os.getcwd(), "./frames/frame.jpg")
     new_image_path = os.path.join(dir_path, "image.jpg")
-    os.system(f"cp {image_path} {new_image_path}")
+    shutil.copy(image_path, new_image_path)
 
-    # Play the audio
     play(audio)
 
 

--- a/narrator.py
+++ b/narrator.py
@@ -43,7 +43,7 @@ def generate_new_line(base64_image):
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Describe this image as if you David Attenborough"},
+                {"type": "text", "text": "Describe this image as if you are David Attenborough"},
                 {
                     "type": "image_url",
                     "image_url": f"data:image/jpeg;base64,{base64_image}",

--- a/narrator.py
+++ b/narrator.py
@@ -25,25 +25,6 @@ script = []
 narrator = "Sir David Attenborough"
 
 
-def on_press(key):
-    if key == keyboard.Key.space:
-        # When space bar is pressed, run the main function which analyzes the image and generates the audio
-        _main()
-
-
-def on_release(key):
-    if key == keyboard.Key.esc:
-        # Stop listener
-        return False
-
-
-# Create a listener
-listener = keyboard.Listener(on_press=on_press, on_release=on_release)
-
-# Start the listener
-listener.start()
-
-
 def encode_image(image_path):
     while True:
         try:
@@ -151,6 +132,24 @@ def main():
             # wait for 5 seconds
             time.sleep(5)
 
+
+def on_press(key):
+    if key == keyboard.Key.space:
+        # When space bar is pressed, run the main function which analyzes the image and generates the audio
+        _main()
+
+
+def on_release(key):
+    if key == keyboard.Key.esc:
+        # Stop listener
+        return False
+
+
+# Create a listener
+listener = keyboard.Listener(on_press=on_press, on_release=on_release)
+
+# Start the listener
+listener.start()
 
 if isPhotoBooth:
     print(f"Press the spacebar to trigger {narrator}")

--- a/narrator.py
+++ b/narrator.py
@@ -43,7 +43,7 @@ def generate_new_line(base64_image):
         {
             "role": "user",
             "content": [
-                {"type": "text", "text": "Describe this image"},
+                {"type": "text", "text": "Describe this image as if you David Attenborough"},
                 {
                     "type": "image_url",
                     "image_url": f"data:image/jpeg;base64,{base64_image}",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ pure-eval==0.2.2
 pydantic==2.4.2
 pydantic_core==2.10.1
 Pygments==2.16.1
+pynput==1.7.6
 requests==2.31.0
 simpleaudio==1.0.4
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ pydantic==2.4.2
 pydantic_core==2.10.1
 Pygments==2.16.1
 pynput==1.7.6
+python-dotenv==1.0.0
 requests==2.31.0
 simpleaudio==1.0.4
 six==1.16.0

--- a/setup.sh
+++ b/setup.sh
@@ -14,3 +14,5 @@ pip install -r requirements.txt
 export ELEVENLABS_VOICE_ID=
 export OPENAI_API_KEY=
 export ELEVENLABS_API_KEY=
+
+export ELEVENLABS_STREAMING=false

--- a/setup.sh
+++ b/setup.sh
@@ -4,15 +4,10 @@
 python3 -m pip install virtualenv
 python3 -m virtualenv venv
 
-# source the virtual environment
+# source the virtual environment to install dependencies
 source venv/bin/activate
 
 # install the dependencies
 pip install -r requirements.txt
 
-# set the environment variables
-export ELEVENLABS_VOICE_ID=
-export OPENAI_API_KEY=
-export ELEVENLABS_API_KEY=
-
-export ELEVENLABS_STREAMING=false
+echo -e "\n\n\nSetup complete. Run $(source venv/bin/activate) to activate the virtual environment.\n\nAlso, please ensure your environment variables are set correctly in the .env file."

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# create a virtual environment
+python3 -m pip install virtualenv
+python3 -m virtualenv venv
+
+# source the virtual environment
+source venv/bin/activate
+
+# install the dependencies
+pip install -r requirements.txt
+
+# set the environment variables
+export ELEVENLABS_VOICE_ID=
+export OPENAI_API_KEY=
+export ELEVENLABS_API_KEY=


### PR DESCRIPTION
### Summary
- Added a `setup.sh` script to facilitate getting the two shell envs setup to run `capture.py` and `narrator.py`.Also, updated README with `setup.sh` usage info. From https://github.com/cbh123/narrator/pull/32
- Updated to the narrator GPT prompt to explicitly have it describe the image as David Attenborough for increased complex descriptors (and humor). From https://github.com/cbh123/narrator/pull/33
- Adds the ability to stream the Eleven Labs text to voice which creates a more immediate experience. From https://github.com/cbh123/narrator/pull/34.
- Added dotenv capabilities, including `.env.example` file and README updates. Based on https://github.com/cbh123/narrator/pull/30/files.
- Format linting
- Added photo booth mode, which only analyzes the image when the space bar is pressed.
- Image file saved along side the corresponding audio file.
