### PR TITLE
Add 'goodbye' to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ In another terminal, run the narrator:
 python narrator.py
 ```
 
+goodbye
+
+


### PR DESCRIPTION
# Summary
- Minor documentation tweak: add a short closing line to the README.

# Why
- Clarifies the end of the quickstart section and confirms successful setup/run steps.

# Impact
- Docs-only change; no code, build, or runtime impact.

# Changes
- Append "goodbye" after the run instructions in `README.md`.

# Type
- docs

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/19518ce0-851c-46c2-a9b0-43fdfcd4c224/task/fbf8d5a8-2bba-4bba-b577-e03c603e08c2))